### PR TITLE
Switch hooks to Ruff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# IntelliJ project files
+.idea/
+.run/
+*.iml
+out
+gen
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -151,10 +158,3 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
-
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 ci:
   autoupdate_schedule: quarterly
-  skip: ["poetry-lock", "sourcery", "pylint", "pytest", "coverage-badge"]
+  skip: ["poetry-lock", "sourcery", "pytest", "coverage-badge"]
 
 repos:
   - repo: meta
@@ -46,32 +46,14 @@ repos:
       - id: prettier
         name: Make code pretty
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.16.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.4
     hooks:
-      - id: pyupgrade
-        args: ["--py311-plus"]
-        name: Align Python code to latest syntax
-
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
-    hooks:
-      - id: black
-        name: Check Python formatting
-
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        name: Sort Python import statements
-        args: ["--filter-files"]
-
-  - repo: https://github.com/hadialqattan/pycln
-    rev: v2.4.0
-    hooks:
-      - id: pycln
-        name: Remove unused imports and variables
-        args: ["--config=pyproject.toml"]
+      - id: ruff
+        name: Lint Python code
+        args: ["--fix"]
+      - id: ruff-format
+        name: Format Python code
 
   # Sourcery
   - repo: https://github.com/sourcery-ai/sourcery
@@ -82,16 +64,6 @@ repos:
         args: ["--diff=git diff HEAD", "--no-summary"]
         files: drawings
         exclude: \.*/__init__\.py
-
-  # Final linting
-  - repo: local
-    hooks:
-      - id: pylint
-        name: Lint Python code with pylint
-        entry: pylint
-        language: system
-        types: ["python"]
-        args: ["-rn", "--rcfile=pyproject.toml"]
 
   # Testing and coverage
   - repo: local

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 [![GitHub last commit](https://img.shields.io/github/last-commit/Bilbottom/python-template)](https://shields.io/badges/git-hub-last-commit)
 
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
-[![code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/Bilbottom/python-template/main.svg)](https://results.pre-commit.ci/latest/github/Bilbottom/python-template/main)
 [![Sourcery](https://img.shields.io/badge/Sourcery-enabled-brightgreen)](https://sourcery.ai)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,20 +18,14 @@ python = "^3.11"
 [tool.poetry.group]
 dev.optional = true
 test.optional = true
-ide.optional = true
 
 [tool.poetry.group.dev.dependencies]
 coverage-badge = "^1.1.0"
-setuptools = "*"  # required until https://github.com/dbrgn/coverage-badge/pull/31
 pre-commit = "^3.6.2"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.0.2"
 pytest-cov = "^4.1.0"
-
-# Packages just for IDE integration
-[tool.poetry.group.ide.dependencies]
-black = "*"
 
 
 [tool.pytest.ini_options]
@@ -44,6 +38,12 @@ line-length = 80
 indent-width = 4
 target-version = "py311"
 
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
 [tool.ruff.lint]
 select = ["F", "I", "N", "PL", "R", "RUF", "S", "UP", "W"]
 ignore = []
@@ -52,8 +52,9 @@ unfixable = []
 # Allow unused variables when underscore-prefixed
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-[tool.ruff.format]
-quote-style = "double"
-indent-style = "space"
-skip-magic-trailing-comma = false
-line-ending = "auto"
+# https://github.com/astral-sh/ruff/issues/4368
+[tool.ruff.lint.extend-per-file-ignores]
+"tests/**/*.py" = [
+    "S101",    #  Use of `assert` detected
+    "PLR2004", #  Magic value used in comparison
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ ide.optional = true
 
 [tool.poetry.group.dev.dependencies]
 coverage-badge = "^1.1.0"
+setuptools = "*"  # required until https://github.com/dbrgn/coverage-badge/pull/31
 pre-commit = "^3.6.2"
-pylint = "3.1.0"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.0.2"
@@ -39,12 +39,21 @@ addopts = "--cov=src --cov-fail-under=80"
 testpaths = ["tests"]
 
 
-[tool.isort]
-profile = "black"
+[tool.ruff]
+line-length = 80
+indent-width = 4
+target-version = "py311"
 
+[tool.ruff.lint]
+select = ["F", "I", "N", "PL", "R", "RUF", "S", "UP", "W"]
+ignore = []
+fixable = ["ALL"]
+unfixable = []
+# Allow unused variables when underscore-prefixed
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-[tool.pylint.format]
-max-line-length = 120
-
-[tool.pylint.MASTER]
-ignore-paths = "^tests/.*$"
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"

--- a/tests/test__main.py
+++ b/tests/test__main.py
@@ -2,7 +2,7 @@
 Unit tests for the ``src.main`` module.
 """
 
-import src.main as main
+from src import main
 
 
 def test__main():


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request switches the project's pre-commit hooks to use Ruff for both linting and formatting Python code, replacing several individual tools. The README has been updated to reflect this change.

- **CI**:
    - Replaced multiple pre-commit hooks (pyupgrade, black, isort, pycln, pylint) with Ruff for linting and formatting Python code.
- **Documentation**:
    - Updated README badges to reflect the switch to Ruff for code linting and formatting.

<!-- Generated by sourcery-ai[bot]: end summary -->